### PR TITLE
Tidyverse updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     ggplot2 (>= 3.0.0),
     tidyselect,
     rlang,
-    forcats,
+    forcats (>= 1.0.0),
     dplyr,
     scales,
     glue

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,7 +54,7 @@ treat_nas <- function(data, age_group, split_by, stack_by, na.rm) {
     # Force missing values to be "Missing"
     data <- dplyr::mutate_at(data,
                              .vars = da_vars,
-                             .funs = forcats::fct_explicit_na, "Missing")
+                             .funs = forcats::fct_na_value_to_level, "Missing")
   }
 
   return(data)

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,7 +30,7 @@ to_character <- function(x) {
 treat_nas <- function(data, age_group, split_by, stack_by, na.rm) {
 
   da_vars <- c(age_group, split_by, stack_by)
-  data    <- dplyr::select(data, da_vars)
+  data    <- dplyr::select(data, any_of(da_vars))
 
   if (na.rm) {
     missing   <- dplyr::mutate_at(data, .vars = da_vars, .funs = is.na)


### PR DESCRIPTION
The forcats change is causing your package to fail `R CMD check` on CRAN — apologies for missing it in our revdep checks but this PR should fix it. (And it includes a bonus fix for some other deprecated tidyselect syntax.)